### PR TITLE
Add fee determination to transactions page

### DIFF
--- a/sandak_flask_project/app/__init__.py
+++ b/sandak_flask_project/app/__init__.py
@@ -19,6 +19,21 @@ def create_app(config_class=Config):
     migrate.init_app(app, db)
     login.init_app(app)
 
+    # Ensure critical columns exist when running without migrations (e.g., CI/containers)
+    @app.before_first_request
+    def ensure_schema_compatibility():
+        try:
+            from sqlalchemy import text
+            with db.engine.connect() as conn:
+                # Check for fee column in managed_transactions
+                res = conn.execute(text("PRAGMA table_info(managed_transactions)")).fetchall()
+                cols = {row[1] for row in res} if res else set()
+                if 'fee' not in cols:
+                    conn.execute(text("ALTER TABLE managed_transactions ADD COLUMN fee NUMERIC DEFAULT 0"))
+        except Exception:
+            # Silently skip to avoid breaking app startup in environments without SQLite PRAGMA
+            pass
+
     # Blueprints
     from app.routes import main_bp
     app.register_blueprint(main_bp)

--- a/sandak_flask_project/app/models.py
+++ b/sandak_flask_project/app/models.py
@@ -118,6 +118,7 @@ class ManagedTransaction(db.Model):
     authority = db.Column(db.String(200), nullable=False)
     service = db.Column(db.String(200), nullable=False)
     description = db.Column(db.Text)
+    fee = db.Column(db.Numeric(12,2), nullable=False, default=0)
     status = db.Column(db.String(50), nullable=False, default='نشطة')
     created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
     updated_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)

--- a/sandak_flask_project/app/routes.py
+++ b/sandak_flask_project/app/routes.py
@@ -144,6 +144,14 @@ def managed_transactions_add():
     service = request.form.get('service') or ''
     description = request.form.get('description') or ''
     status = request.form.get('status') or 'نشطة'
+    fee_raw = (request.form.get('fee') or '').strip()
+    try:
+        fee_value = float(fee_raw) if fee_raw != '' else 0.0
+        if fee_value < 0:
+            raise ValueError('negative fee')
+    except Exception:
+        flash('قيمة الرسوم غير صحيحة', 'danger')
+        return redirect(url_for('main.managed_transactions_list'))
 
     if authority not in AUTHORITIES or not service or status not in STATUSES:
         flash('الرجاء تعبئة الحقول بشكل صحيح', 'danger')
@@ -153,6 +161,7 @@ def managed_transactions_add():
         authority=authority,
         service=service.strip(),
         description=description.strip(),
+        fee=fee_value,
         status=status,
     )
     db.session.add(row)
@@ -169,6 +178,17 @@ def managed_transactions_edit(item_id):
     service = request.form.get('service') or row.service
     description = request.form.get('description') if request.form.get('description') is not None else row.description
     status = request.form.get('status') or row.status
+    fee_raw = request.form.get('fee')
+    new_fee = row.fee
+    if fee_raw is not None:
+        try:
+            fee_value = float((fee_raw or '').strip() or 0)
+            if fee_value < 0:
+                raise ValueError('negative fee')
+            new_fee = fee_value
+        except Exception:
+            flash('قيمة الرسوم غير صحيحة', 'danger')
+            return redirect(url_for('main.managed_transactions_list'))
 
     if authority not in AUTHORITIES or not service or status not in STATUSES:
         flash('بيانات غير صحيحة', 'danger')
@@ -178,6 +198,7 @@ def managed_transactions_edit(item_id):
     row.service = service.strip()
     row.description = (description or '').strip()
     row.status = status
+    row.fee = new_fee
     db.session.commit()
     flash('تم تحديث المعاملة', 'success')
     return redirect(url_for('main.managed_transactions_list'))

--- a/sandak_flask_project/app/templates/transactions.html
+++ b/sandak_flask_project/app/templates/transactions.html
@@ -37,6 +37,7 @@
           <th>الجهة</th>
           <th>الخدمة</th>
           <th>الوصف</th>
+          <th>الرسوم</th>
           <th>الحالة</th>
           <th style="width: 160px;">إجراءات</th>
         </tr>
@@ -47,6 +48,7 @@
           <td>{{ item.authority }}</td>
           <td>{{ item.service }}</td>
           <td class="text-muted">{{ item.description or '-' }}</td>
+          <td>{{ ('%.2f' % item.fee) if item.fee is not none else '0.00' }}</td>
           <td>
             <span class="badge {% if item.status=='نشطة' %}bg-success{% elif item.status=='معلقة' %}bg-warning text-dark{% else %}bg-secondary{% endif %}">{{ item.status }}</span>
           </td>
@@ -83,6 +85,10 @@
                   <div class="mb-3">
                     <label class="form-label">وصف مختصر</label>
                     <textarea class="form-control" name="description" rows="3">{{ item.description or '' }}</textarea>
+                  </div>
+                  <div class="mb-3">
+                    <label class="form-label">الرسوم (ر.ع)</label>
+                    <input type="number" step="0.01" min="0" class="form-control" name="fee" value="{{ ('%.2f' % item.fee) if item.fee is not none else '0.00' }}">
                   </div>
                   <div class="mb-3">
                     <label class="form-label">الحالة</label>
@@ -136,6 +142,10 @@
           <div class="mb-3">
             <label class="form-label">وصف مختصر</label>
             <textarea class="form-control" name="description" rows="3" placeholder="وصف مختصر للخدمة"></textarea>
+          </div>
+          <div class="mb-3">
+            <label class="form-label">الرسوم (ر.ع)</label>
+            <input type="number" step="0.01" min="0" class="form-control" name="fee" placeholder="0.00" value="0.00">
           </div>
           <div class="mb-3">
             <label class="form-label">الحالة</label>

--- a/sandak_flask_project/migrations/versions/0a1b2c3d4e5f_create_managed_transactions.py
+++ b/sandak_flask_project/migrations/versions/0a1b2c3d4e5f_create_managed_transactions.py
@@ -23,6 +23,7 @@ def upgrade() -> None:
         sa.Column('authority', sa.String(length=200), nullable=False),
         sa.Column('service', sa.String(length=200), nullable=False),
         sa.Column('description', sa.Text(), nullable=True),
+        sa.Column('fee', sa.Numeric(12, 2), nullable=False, server_default='0'),
         sa.Column('status', sa.String(length=50), nullable=False, server_default='نشطة'),
         sa.Column('created_at', sa.DateTime(), nullable=False),
         sa.Column('updated_at', sa.DateTime(), nullable=False),
@@ -30,6 +31,7 @@ def upgrade() -> None:
     # Drop server_default after creation
     with op.batch_alter_table('managed_transactions') as batch_op:
         batch_op.alter_column('status', server_default=None)
+        batch_op.alter_column('fee', server_default=None)
 
 
 def downgrade() -> None:

--- a/sandak_flask_project/migrations/versions/a1b2c3e4f5g6_add_fee_to_managed_transactions.py
+++ b/sandak_flask_project/migrations/versions/a1b2c3e4f5g6_add_fee_to_managed_transactions.py
@@ -1,0 +1,28 @@
+"""add fee to managed_transactions
+
+Revision ID: a1b2c3e4f5g6
+Revises: 0a1b2c3d4e5f
+Create Date: 2025-09-27 12:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'a1b2c3e4f5g6'
+down_revision = '0a1b2c3d4e5f'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table('managed_transactions') as batch_op:
+        batch_op.add_column(sa.Column('fee', sa.Numeric(12, 2), nullable=False, server_default='0'))
+        batch_op.alter_column('fee', server_default=None)
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('managed_transactions') as batch_op:
+        batch_op.drop_column('fee')
+


### PR DESCRIPTION
Add a fee selection feature to the transactions page.

This PR introduces a `fee` column to the `ManagedTransaction` model, updates the transactions UI to display and allow editing of fees, and modifies backend routes to handle fee input, validation, and persistence. An Alembic migration is included to add the new column. A startup fallback in `app/__init__.py` ensures schema compatibility for environments where migrations might not be applied.

---
<a href="https://cursor.com/background-agent?bcId=bc-a1c6205e-a3e1-4474-8ab9-1e8aeb2c35f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a1c6205e-a3e1-4474-8ab9-1e8aeb2c35f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit e6f1f2b58fd6092bd36a61141d28787fbf75c2ac. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->