### PR TITLE
Fix staff display error for accounting roles

### DIFF
--- a/sandak_flask_project/app/admin.py
+++ b/sandak_flask_project/app/admin.py
@@ -16,6 +16,15 @@ PERMISSION_OPTIONS = [
     ('reports', 'عرض التقارير'),
 ]
 
+# Centralized roles and their Arabic labels
+# Keys are stored in DB, values are shown in UI
+ROLE_OPTIONS = {
+    'admin': 'مدير',
+    'accounting_manager': 'مدير محاسبين',
+    'accountant': 'محاسب',
+    'staff': 'موظف',
+}
+
 
 def admin_required(view_func):
     @wraps(view_func)
@@ -112,7 +121,7 @@ def api_transactions_by_ministry():
 @admin_required
 def employees_list():
     employees = User.query.order_by(User.id.desc()).all()
-    return render_template('admin/employees.html', employees=employees, permission_options=PERMISSION_OPTIONS)
+    return render_template('admin/employees.html', employees=employees, permission_options=PERMISSION_OPTIONS, role_options=ROLE_OPTIONS)
 
 
 @admin_bp.route('/employees/create', methods=['GET', 'POST'])
@@ -123,6 +132,11 @@ def employees_create():
         email = request.form.get('email')
         password = request.form.get('password')
         role = request.form.get('role') or 'staff'
+        # Validate/normalize role
+        if role not in ROLE_OPTIONS:
+            # Accept Arabic labels submitted from client as well
+            reverse_map = {label: key for key, label in ROLE_OPTIONS.items()}
+            role = reverse_map.get(role, 'staff')
         if not name or not email or not password:
             flash('الرجاء تعبئة الحقول المطلوبة', 'warning')
             return render_template('admin/employee_form.html', permission_options=PERMISSION_OPTIONS)
@@ -140,7 +154,7 @@ def employees_create():
         db.session.commit()
         flash('تمت إضافة الموظف', 'success')
         return redirect(url_for('admin.employees_list'))
-    return render_template('admin/employee_form.html', permission_options=PERMISSION_OPTIONS)
+    return render_template('admin/employee_form.html', permission_options=PERMISSION_OPTIONS, role_options=ROLE_OPTIONS)
 
 
 @admin_bp.route('/employees/<int:user_id>/edit', methods=['GET', 'POST'])
@@ -152,6 +166,9 @@ def employees_edit(user_id):
         user.email = request.form.get('email') or user.email
         role = request.form.get('role')
         if role:
+            if role not in ROLE_OPTIONS:
+                reverse_map = {label: key for key, label in ROLE_OPTIONS.items()}
+                role = reverse_map.get(role, user.role)
             user.role = role
         password = request.form.get('password')
         if password:
@@ -164,7 +181,7 @@ def employees_edit(user_id):
         db.session.commit()
         flash('تم تحديث بيانات الموظف', 'success')
         return redirect(url_for('admin.employees_list'))
-    return render_template('admin/employee_form.html', user=user, permission_options=PERMISSION_OPTIONS)
+    return render_template('admin/employee_form.html', user=user, permission_options=PERMISSION_OPTIONS, role_options=ROLE_OPTIONS)
 
 
 @admin_bp.route('/employees/<int:user_id>/delete', methods=['POST'])

--- a/sandak_flask_project/app/templates/admin/employee_form.html
+++ b/sandak_flask_project/app/templates/admin/employee_form.html
@@ -23,8 +23,9 @@
         <div class="col-md-6">
           <label class="form-label">الدور</label>
           <select class="form-select" name="role">
-            <option value="admin" {{ 'selected' if user and user.role=='admin' else '' }}>مدير</option>
-            <option value="staff" {{ 'selected' if user and user.role=='staff' else '' }}>موظف</option>
+            {% for value, label in role_options.items() %}
+            <option value="{{ value }}" {{ 'selected' if user and user.role==value else '' }}>{{ label }}</option>
+            {% endfor %}
           </select>
         </div>
         <div class="col-12">

--- a/sandak_flask_project/app/templates/admin/employees.html
+++ b/sandak_flask_project/app/templates/admin/employees.html
@@ -23,7 +23,10 @@
         <tr>
           <td>{{ u.username }}</td>
           <td>{{ u.email }}</td>
-          <td><span class="badge bg-{{ 'danger' if u.role=='admin' else 'secondary' }}">{{ u.role }}</span></td>
+          <td>
+            {% set label = role_options.get(u.role, u.role) %}
+            <span class="badge bg-{{ 'danger' if u.role=='admin' else 'secondary' }}">{{ label }}</span>
+          </td>
           <td>
             {% if u.role == 'admin' %}
               <span class="badge bg-success">كل الصلاحيات</span>


### PR DESCRIPTION
Add and correctly display "محاسب" and "مدير محاسبين" roles.

Fixes an issue where selecting "محاسب" or "مدير محاسبين" for a new employee incorrectly resulted in the "staff" role being assigned and displayed.

---
<a href="https://cursor.com/background-agent?bcId=bc-ae69db5d-baac-4f23-a10b-d87b224e8bc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ae69db5d-baac-4f23-a10b-d87b224e8bc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

