### PR TITLE
Fix flask before_first_request attribute error

### DIFF
--- a/sandak_flask_project/app/__init__.py
+++ b/sandak_flask_project/app/__init__.py
@@ -20,7 +20,6 @@ def create_app(config_class=Config):
     login.init_app(app)
 
     # Ensure critical columns exist when running without migrations (e.g., CI/containers)
-    @app.before_first_request
     def ensure_schema_compatibility():
         try:
             from sqlalchemy import text
@@ -33,6 +32,10 @@ def create_app(config_class=Config):
         except Exception:
             # Silently skip to avoid breaking app startup in environments without SQLite PRAGMA
             pass
+
+    # Run once at startup under the app context (Flask 3.x compatible)
+    with app.app_context():
+        ensure_schema_compatibility()
 
     # Blueprints
     from app.routes import main_bp


### PR DESCRIPTION
Replace deprecated `@app.before_first_request` with a direct call in `create_app` to resolve `AttributeError` in Flask 3.x.

The `@app.before_first_request` decorator was removed in Flask 3.x, causing an `AttributeError`. This change moves the one-time schema compatibility check into the `create_app` function, ensuring it runs at startup within an application context, which is the recommended pattern for Flask 3.x.

---
<a href="https://cursor.com/background-agent?bcId=bc-f722f3c8-7623-471a-9750-8af19ee547e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f722f3c8-7623-471a-9750-8af19ee547e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

