### PR TITLE
Navigate transaction card to status

### DIFF
--- a/sandak_flask_project/app/templates/dashboard.html
+++ b/sandak_flask_project/app/templates/dashboard.html
@@ -31,7 +31,23 @@
           <div class="h4 mb-0">{{ card.value }}</div>
         </div>
       </div>
+      {% if card.title == 'عدد المعاملات' %}
+      <div class="card-footer bg-white border-0 pt-0 px-3 pb-3">
+        <div class="d-flex gap-3 flex-wrap small">
+          <a href="{{ url_for('main.dashboard', status='completed') }}" class="text-success text-decoration-none">
+            منتهية
+          </a>
+          <a href="{{ url_for('main.dashboard', status='overdue') }}" class="text-danger text-decoration-none">
+            متأخرة
+          </a>
+          <a href="{{ url_for('main.dashboard', status='in_progress') }}" class="text-warning text-decoration-none">
+            قيد الإجراء
+          </a>
+        </div>
+      </div>
+      {% else %}
       <a href="{{ card.url }}" class="stretched-link"></a>
+      {% endif %}
     </div>
   </div>
   {% endfor %}


### PR DESCRIPTION
Add inline links to the 'Number of Transactions' dashboard card to allow direct navigation to filtered transaction views by status.

---
<a href="https://cursor.com/background-agent?bcId=bc-151d7a48-a902-4632-91ad-b056bbd9464c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-151d7a48-a902-4632-91ad-b056bbd9464c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

