### PR TITLE
Add new transaction to created transactions page

### DIFF
--- a/sandak_flask_project/app/routes.py
+++ b/sandak_flask_project/app/routes.py
@@ -210,7 +210,7 @@ def new_transaction():
         db.session.add(t)
         db.session.commit()
         flash('Transaction created.')
-        return redirect(url_for('main.dashboard'))
+        return redirect(url_for('main.transactions_new'))
     return render_template('transaction_form.html', form=form)
 
 
@@ -273,9 +273,25 @@ def add_gov_transaction():
             employee_id=current_user.id,
         )
         db.session.add(rec)
+        # Also create a standard Transaction entry so it appears in the "new" list
+        try:
+            m = Ministry.query.get(int(ministry_id)) if ministry_id else None
+            s_obj = Service.query.get(int(service_id)) if service_id else None
+        except Exception:
+            m = None
+            s_obj = None
+
+        std_tx = Transaction(
+            client_id=client_row.id if client_row and client_row.id else None,
+            service_type=(s_obj.name if s_obj else None),
+            office=(m.name if m else None),
+            fee=0,
+            details=notes,
+        )
+        db.session.add(std_tx)
         db.session.commit()
         flash('تم حفظ المعاملة بنجاح', 'success')
-        return redirect(url_for('main.dashboard'))
+        return redirect(url_for('main.transactions_new'))
 
     ministries = Ministry.query.order_by(Ministry.name).all()
     return render_template('add_transaction.html', ministries=ministries)

--- a/sandak_flask_project/app/templates/dashboard.html
+++ b/sandak_flask_project/app/templates/dashboard.html
@@ -15,7 +15,7 @@
 <div class="row g-3 mb-4">
   {% set stats_cards = [
     {'title':'عدد العملاء','value':total_clients,'icon':'fa-users','color':'primary','url': url_for('main.clients')},
-    {'title':'عدد المعاملات','value':total_transactions,'icon':'fa-file-lines','color':'success','url': url_for('main.managed_transactions_list')},
+    {'title':'عدد المعاملات','value':total_transactions,'icon':'fa-file-lines','color':'success','url': url_for('main.transactions_new')},
     {'title':'قيد الإجراء','value':in_progress_count,'icon':'fa-hourglass-half','color':'warning','url': url_for('main.dashboard', status='in_progress')},
     {'title':'المعاملات المتأخرة','value':overdue_count,'icon':'fa-triangle-exclamation','color':'danger','url': url_for('main.dashboard', status='overdue')}
   ] %}
@@ -45,6 +45,7 @@
           </a>
         </div>
       </div>
+      <a href="{{ url_for('main.transactions_new') }}" class="stretched-link" aria-label="فتح صفحة المعاملات التي تم إنشاؤها"></a>
       {% else %}
       <a href="{{ card.url }}" class="stretched-link"></a>
       {% endif %}


### PR DESCRIPTION
Ensure all newly created transactions appear on the `transactions_new` page and the dashboard's transaction card links directly to it.

---
<a href="https://cursor.com/background-agent?bcId=bc-14f87da6-d3c0-42bf-b84e-ac314e28bfff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-14f87da6-d3c0-42bf-b84e-ac314e28bfff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

