### PR TITLE
Update new transactions to underway

### DIFF
--- a/sandak_flask_project/app/routes.py
+++ b/sandak_flask_project/app/routes.py
@@ -456,6 +456,9 @@ def update_transaction_status(transaction_id):
         return redirect(url_for('main.dashboard'))
 
     status = (request.form.get('status') or '').strip()
+    # Coerce any attempt to set 'new' to 'in_progress'
+    if status == 'new':
+        status = 'in_progress'
     if status not in ('new', 'in_progress', 'completed'):
         flash('حالة غير صالحة', 'danger')
         return redirect(url_for('main.dashboard'))


### PR DESCRIPTION
Coerce 'new' transaction status to 'in_progress' to ensure transactions are always 'under processing' when initially set.

---
<a href="https://cursor.com/background-agent?bcId=bc-40f87830-bc9e-4588-b20a-3c9c460d6984"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-40f87830-bc9e-4588-b20a-3c9c460d6984"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

