### PR TITLE
Fix incomplete transaction display

### DIFF
--- a/sandak_flask_project/app/static/js/main.js
+++ b/sandak_flask_project/app/static/js/main.js
@@ -27,7 +27,11 @@ document.addEventListener('DOMContentLoaded', function () {
       document.querySelectorAll('table[data-enhance="table"]').forEach(function (tbl) {
         const options = {
           searchable: true,
-          fixedHeight: true,
+          // Allow the table to grow naturally so more rows are visible
+          fixedHeight: false,
+          // Show more rows by default and allow user to change page size
+          perPage: 25,
+          perPageSelect: [10, 25, 50, 100],
           labels: {
             placeholder: 'بحث...',
             perPage: '{select} لكل صفحة',


### PR DESCRIPTION
Update table initialization to show more rows by default and allow per-page selection.

This fixes an issue where only 4 transactions were displayed due to `Simple-DataTables` having a fixed height and a low default `perPage` setting.

---
<a href="https://cursor.com/background-agent?bcId=bc-6ba4d9e1-6248-49aa-8b3a-c17d5af5c602"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6ba4d9e1-6248-49aa-8b3a-c17d5af5c602"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

