### PR TITLE
Remove page filter to show all pages

### DIFF
--- a/sandak_flask_project/app/static/js/main.js
+++ b/sandak_flask_project/app/static/js/main.js
@@ -29,9 +29,9 @@ document.addEventListener('DOMContentLoaded', function () {
           searchable: true,
           // Allow the table to grow naturally so more rows are visible
           fixedHeight: false,
-          // Show more rows by default and allow user to change page size
-          perPage: 25,
-          perPageSelect: [10, 25, 50, 100],
+          // Disable pagination and show all rows; hide per-page selector
+          perPage: 0,
+          perPageSelect: false,
           labels: {
             placeholder: 'بحث...',
             perPage: '{select} لكل صفحة',


### PR DESCRIPTION
Disable table pagination to show all rows without limits.

---
<a href="https://cursor.com/background-agent?bcId=bc-8599c3b6-7651-4895-8666-8ab86e1aeae6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8599c3b6-7651-4895-8666-8ab86e1aeae6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

