### PR TITLE
Fix url_for build error in templates

### DIFF
--- a/sandak_flask_project/app/routes.py
+++ b/sandak_flask_project/app/routes.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, render_template, redirect, url_for, flash, request, jsonify
+from flask import Blueprint, render_template, redirect, url_for, flash, request, jsonify, current_app, send_from_directory
 from datetime import datetime, timedelta
 from flask_login import login_required, current_user
 from app import db
@@ -281,6 +281,20 @@ def add_gov_transaction():
 
     ministries = Ministry.query.order_by(Ministry.name).all()
     return render_template('add_transaction.html', ministries=ministries)
+
+
+# Serve a basic service-worker to silence 404s in browsers expecting it
+@main_bp.route('/service-worker.js')
+def service_worker():
+    try:
+        # If a real static file exists, serve it
+        static_dir = current_app.static_folder
+        return send_from_directory(static_dir, 'service-worker.js')
+    except Exception:
+        # Fallback: serve a minimal no-op service worker
+        from flask import Response
+        content = "self.addEventListener('install',()=>self.skipWaiting());self.addEventListener('activate',event=>event.waitUntil(clients.claim()));self.addEventListener('fetch',()=>{});"
+        return Response(content, mimetype='application/javascript')
 
 
 # Services API for dependent dropdown

--- a/sandak_flask_project/app/templates/dashboard.html
+++ b/sandak_flask_project/app/templates/dashboard.html
@@ -15,7 +15,7 @@
 <div class="row g-3 mb-4">
   {% set stats_cards = [
     {'title':'عدد العملاء','value':total_clients,'icon':'fa-users','color':'primary','url': url_for('main.clients')},
-    {'title':'عدد المعاملات','value':total_transactions,'icon':'fa-file-lines','color':'success','url': url_for('main.transactions_new')},
+    {'title':'عدد المعاملات','value':total_transactions,'icon':'fa-file-lines','color':'success','url': url_for('main.managed_transactions_list')},
     {'title':'قيد الإجراء','value':in_progress_count,'icon':'fa-hourglass-half','color':'warning','url': url_for('main.dashboard', status='in_progress')},
     {'title':'المعاملات المتأخرة','value':overdue_count,'icon':'fa-triangle-exclamation','color':'danger','url': url_for('main.dashboard', status='overdue')}
   ] %}
@@ -45,7 +45,7 @@
           </a>
         </div>
       </div>
-      <a href="{{ url_for('main.transactions_new') }}" class="stretched-link" aria-label="فتح صفحة المعاملات التي تم إنشاؤها"></a>
+      <a href="{{ url_for('main.managed_transactions_list') }}" class="stretched-link" aria-label="فتح صفحة المعاملات"></a>
       {% else %}
       <a href="{{ card.url }}" class="stretched-link"></a>
       {% endif %}


### PR DESCRIPTION
Correct dashboard transaction links to `managed_transactions_list` and add a `service-worker.js` route to resolve `BuildError` and 404s.

---
<a href="https://cursor.com/background-agent?bcId=bc-7476edd7-3286-4620-9c70-097d326e04c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7476edd7-3286-4620-9c70-097d326e04c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

